### PR TITLE
Rename INKPLATE_2BIT to INKPLATE_3BIT

### DIFF
--- a/example.py
+++ b/example.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     time.sleep(5)
 
     # You can switch display modes anytime
-    display.selectDisplayMode(display.INKPLATE_2BIT)
+    display.selectDisplayMode(display.INKPLATE_3BIT)
 
     display.clearDisplay()
     for r in range(4):

--- a/exampleSd.py
+++ b/exampleSd.py
@@ -1,7 +1,7 @@
 import os
 from inkplate import Inkplate
 
-display = Inkplate(Inkplate.INKPLATE_2BIT)
+display = Inkplate(Inkplate.INKPLATE_3BIT)
 display.begin()
 
 # This prints all the files on card

--- a/inkplate.py
+++ b/inkplate.py
@@ -625,7 +625,7 @@ class InkplatePartial:
 
 class Inkplate:
     INKPLATE_1BIT = 0
-    INKPLATE_2BIT = 1
+    INKPLATE_3BIT = 1
 
     BLACK = 1
     WHITE = 0
@@ -947,4 +947,3 @@ class Inkplate:
                         val >>= 1
 
                     self.drawPixel(x + i, y + h - j, val)
-


### PR DESCRIPTION
The documentation refers to `INKPLATE_3BIT` (for example, here: https://inkplate.readthedocs.io/en/latest/micropython.html#selectdisplaymode), but the library calls the variable `INKPLATE_2BIT`. This changes the name to match the docs.