### PR TITLE
inkplate: fillScreen: Pass the specified color to fillRect

### DIFF
--- a/inkplate.py
+++ b/inkplate.py
@@ -806,7 +806,7 @@ class Inkplate:
         self.endWrite()
 
     def fillScreen(self, c):
-        self.fillRect(0, 0, self.width(), self.height())
+        self.fillRect(0, 0, self.width(), self.height(), c)
 
     def drawLine(self, x0, y0, x1, y1, c):
         self.startWrite()


### PR DESCRIPTION
Otherwise it fails with:

```python
Traceback (most recent call last):
  File "<stdin>", line 25, in <module>
  File "inkplate.py", line 809, in fillScreen
TypeError: function takes 6 positional arguments but 5 were given
```