### PR TITLE
Replace line/rect loops

### DIFF
--- a/inkplate10.py
+++ b/inkplate10.py
@@ -840,6 +840,18 @@ class Inkplate:
     def startWrite(self):
         pass
 
+    def _rotateCoordinates(self, x, y):
+        if self.rotation == 1:
+            x, y = y, x
+            x = self.height() - x - 1
+        elif self.rotation == 2:
+            x = self.width() - x - 1
+            y = self.height() - y - 1
+        elif self.rotation == 3:
+            x, y = y, x
+            y = self.width() - y - 1
+        return x, y
+
     def writePixel(self, x, y, c):
         if x > self.width() - 1 or y > self.height() - 1 or x < 0 or y < 0:
             return
@@ -857,16 +869,41 @@ class Inkplate:
         )
 
     def writeFillRect(self, x, y, w, h, c):
+        x, y = self._rotateCoordinates(x, y)
+        if self.rotation in (1, 3):
+            w, h = h, w
+        if self.rotation in (1, 2):
+            x -= w - 1
+        if self.rotation in (2, 3):
+            y -= h - 1
         (self.ipm.fill_rect if self.displayMode == self.INKPLATE_1BIT else self.ipg.fill_rect)(
             x, y, w, h, c
             )
 
     def writeFastVLine(self, x, y, h, c):
+        if self.rotation in (1, 3):
+            self._writeFastHLine(x, y, h, c)
+            return
+        self._writeFastVLine(x, y, h, c)
+
+    def _writeFastVLine(self, x, y, h, c):
+        x, y = self._rotateCoordinates(x, y)
+        if self.rotation in (2, 3):
+            y -= h - 1
         (self.ipm.vline if self.displayMode == self.INKPLATE_1BIT else self.ipg.vline)(
             x, y, h, c
             )
 
     def writeFastHLine(self, x, y, w, c):
+        if self.rotation in (1, 3):
+            self._writeFastVLine(x, y, w, c)
+            return
+        self._writeFastHLine(x, y, w, c)
+
+    def _writeFastHLine(self, x, y, w, c):
+        x, y = self._rotateCoordinates(x, y)
+        if self.rotation in (1, 2):
+            x -= w - 1
         (self.ipm.hline if self.displayMode == self.INKPLATE_1BIT else self.ipg.hline)(
             x, y, w, c
             )

--- a/inkplate10.py
+++ b/inkplate10.py
@@ -857,17 +857,19 @@ class Inkplate:
         )
 
     def writeFillRect(self, x, y, w, h, c):
-        for j in range(w):
-            for i in range(h):
-                self.writePixel(x + j, y + i, c)
+        (self.ipm.fill_rect if self.displayMode == self.INKPLATE_1BIT else self.ipg.fill_rect)(
+            x, y, w, h, c
+            )
 
     def writeFastVLine(self, x, y, h, c):
-        for i in range(h):
-            self.writePixel(x, y + i, c)
+        (self.ipm.vline if self.displayMode == self.INKPLATE_1BIT else self.ipg.vline)(
+            x, y, h, c
+            )
 
     def writeFastHLine(self, x, y, w, c):
-        for i in range(w):
-            self.writePixel(x + i, y, c)
+        (self.ipm.hline if self.displayMode == self.INKPLATE_1BIT else self.ipg.hline)(
+            x, y, w, c
+            )
 
     def writeLine(self, x0, y0, x1, y1, c):
         self.GFX.line(x0, y0, x1, y1, c)


### PR DESCRIPTION
By replacing the writeFillRect, writeFastVLine, and writeFastHLine
for loops calling writePixel with direct calls to fill_rect, vline,
and hline respectively, speed gains of about 660, 54, and 283 times
are achieved, with identical visual result for rectangles of 500x500
pixels, and 500 lines of 500 pixel lengths.

The new versions of these calls use the same mechanism for selecting
whether the monochrome or grayscale version should be used as
writePixel does.

Similar changes to inkplate6.py would probably produce similar gains,
but as I don't have that version of the Inkplate, I can't test that.