### PR TITLE
Fix Inkplate 6 Color touchpads

### DIFF
--- a/PCAL6416A.py
+++ b/PCAL6416A.py
@@ -197,3 +197,5 @@ class gpioPin:
     
     def digitalRead(self):
         return self.PCAL6416A.digitalRead(self.pin)
+    
+    __call__ = digitalRead

--- a/inkplate6_COLOR.py
+++ b/inkplate6_COLOR.py
@@ -104,7 +104,12 @@ class Inkplate:
         self.EPAPER_DC_PIN = Pin(EPAPER_DC_PIN, Pin.OUT)
         self.EPAPER_CS_PIN = Pin(EPAPER_CS_PIN, Pin.OUT)
 
-        self.SD_ENABLE = gpioPin(self._PCAL6416A, 10, modeOUTPUT)
+        self.SD_ENABLE = gpioPin(self._PCAL6416A, 13, modeOUTPUT)
+
+        # Touchpads
+        self.TOUCH1 = gpioPin(self._PCAL6416A, 10, modeINPUT_PULLUP)
+        self.TOUCH2 = gpioPin(self._PCAL6416A, 11, modeINPUT_PULLUP)
+        self.TOUCH3 = gpioPin(self._PCAL6416A, 12, modeINPUT_PULLUP)
 
         self.framebuf = bytearray(D_ROWS * D_COLS // 2)
 
@@ -153,8 +158,6 @@ class Inkplate:
 
         self.sendCommand(b"\x50")
         self.sendData(b"\x37")
-
-        self.setPCALForLowPower()
 
         self._panelState = True
 


### PR DESCRIPTION
**Expected behavior:**
 `Examples/Inkplate6COLOR/touchpads.py` should work on the Inkplate 6 Color out of the box

**Actual behavior:**
The following error occurs:
```
Traceback (most recent call last):
  File "<stdin>", line 24, in <module>
AttributeError: 'Inkplate' object has no attribute 'TOUCH1'
```

**Problem:**
The GPIO pins were not being correctly initialized for the Inkplate 6 Color

**Solution:**
Remove `self.setPCALForLowPower()` as this sets all GPIO pins to output. We want the touchpads to be input.
Initialize `TOUCH1`, `TOUCH2`, and `TOUCH3` to use GPIO pins 10, 11, and 12 respectively (all in pull-up input mode).

Previously, `SD_ENABLE` was assigned pin 10, but that corresponds to touchpad 1. I moved `SD_ENABLE` to pin 13 as that is where it is on the Inkplate 6 Plus. I'm not sure if this is correct as I've been unable to find a circuit schematic for the Inkplate 6 Color.