### PR TITLE
Fix Inkplate 6 Color battery reading

### DIFF
--- a/Examples/Inkplate6COLOR/battery.py
+++ b/Examples/Inkplate6COLOR/battery.py
@@ -1,0 +1,13 @@
+from inkplate6_COLOR import Inkplate
+
+display = Inkplate()
+
+if __name__ == "__main__":
+    display.begin()
+    display.clearDisplay()
+
+    battery = str(display.readBattery())
+
+    display.setTextSize(2)
+    display.printText(100, 100, "batt: " + battery + "V")
+    display.display()


### PR DESCRIPTION
Expected behavior:
`Inkplate.readBattery` should read the battery level of an Inkplate 6 Color

Actual behavior:
The following error occurs:
```
Traceback (most recent call last):
  File "<stdin>", line 22, in <module>
  File "inkplate6_COLOR.py", line 467, in readBattery
AttributeError: type object 'Inkplate' has no attribute 'VBAT_EN'
```

Problem:
The GPIO pins were not being correctly initialized for reading the battery.
The `readBattery` function was not correctly using the PCAL6416A class

Solution:
Initialize GPIO pins for reading battery
Update `readBattery` function to properly read the voltage
Add a comment explaining the battery voltage calculation equation